### PR TITLE
KX-11575: Use password type control for Azure OpenAI token

### DIFF
--- a/src/CMS/App_Data/CIRepository/@global/cms.settingskey/kenticoxperienceazureopenaiapikey.xml
+++ b/src/CMS/App_Data/CIRepository/@global/cms.settingskey/kenticoxperienceazureopenaiapikey.xml
@@ -8,6 +8,9 @@
     <![CDATA[{$settingskey.xperienceazureopenai.apikey.description$}]]>
   </KeyDescription>
   <KeyDisplayName>{$settingskey.xperienceazureopenai.apikey$}</KeyDisplayName>
+  <KeyEditingControlPath>
+    <![CDATA[~/CMSModules/Membership/FormControls/Passwords/EncryptedPassword.ascx]]>
+  </KeyEditingControlPath>
   <KeyExplanationText />
   <KeyGUID>7c2a824c-f8fe-4154-8349-7a5a48471cb9</KeyGUID>
   <KeyIsGlobal>False</KeyIsGlobal>


### PR DESCRIPTION
### Motivation

JIRA: https://kentico.atlassian.net/browse/KX-11575

![image](https://github.com/Kentico/xperience-module-openai-azure/assets/64188398/5902f2a3-7c54-4418-afe3-291b61b6e2b4)

### How to test

- Go to settings application - Content/Azure OpenAI
- Check that `Azure OpenAI API key` field is represented by password control - the actual token characters are hidden behind dots

