### PR TITLE
Fixed a typo in a setting name in the installation steps of the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Xperience Azure OpenAI integration
 
-This custom module allows Xperience users to [automatically select](https://docs.kentico.com/x/IgqRBg) the best fitting categories for a page based on its content using [Azure OpenAI](https://azure.microsoft.com/en-us/products/ai-services/openai-service).
+This custom module allows Kentico Xperience 13 users to [automatically select](https://docs.kentico.com/x/IgqRBg) the best fitting categories for a page based on its content using [Azure OpenAI](https://azure.microsoft.com/en-us/products/ai-services/openai-service).
 
 
 ## Installation


### PR DESCRIPTION
Fixed a typo in a setting name in the installation steps of the readme.