### PR TITLE
KX-17099 Fix binding redirect for ContinuesIntegration utility

### DIFF
--- a/src/Lib/ContinuousIntegration.exe.config
+++ b/src/Lib/ContinuousIntegration.exe.config
@@ -30,6 +30,10 @@
         <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>


### PR DESCRIPTION
### Motivation

Running `ContinuousIntegration.exe` utility ends with exception that it cannot find assembly `Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0`. This fix adds binding redirect for the utility so that the CI operation can run without an issue.

### How to test

- Clone the repository and follow the steps in [https://github.com/Kentico/xperience-module-openai-azure?tab=readme-ov-file#development-environment-setup](README) to setup the repository.
- Make sure you can finish the setup without an issue
